### PR TITLE
Attempt to use native move animation

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -2024,6 +2024,11 @@ minimumLineSpacingForSectionAtIndex:(NSInteger)section
           [super insertItemsAtIndexPaths:change.indexPaths];
           numberOfUpdates++;
         }
+        
+        for (_ASHierarchyItemMoveChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeMove]) {
+          [super moveItemAtIndexPath:change.sourceIndexPath toIndexPath:change.destinationIndexPath];
+          numberOfUpdates++;
+        }
       } completion:^(BOOL finished){
         as_activity_scope(as_activity_create("Handle collection update completion", changeSet.rootActivity, OS_ACTIVITY_FLAG_DEFAULT));
         as_log_verbose(ASCollectionLog(), "Update animation finished %{public}@", self.collectionNode);

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -692,6 +692,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 {
   return 0 < (_originalDeleteSectionChanges.count + _originalDeleteItemChanges.count
               +_originalInsertSectionChanges.count + _originalInsertItemChanges.count
+              +_moveItemChanges.count
               + _reloadSectionChanges.count + _reloadItemChanges.count);
 }
 


### PR DESCRIPTION
*Note:* This change is based on the lesson learnt from older PR https://github.com/facebookarchive/AsyncDisplayKit/pull/3169 for AsyncDisplayKit `v2.0.1`. We use this in production, and it's working so far.

- Move `ASCollectionElement` in the map instead of creating a new one (aka node)
- Gather moveFrom to delete
  - Delete in descending order
- Gather moveTo to insert
  - Insert in ascending order

TODO:
- Check cases for move across sections

Remark:
- Delete and Move From the same index path will crash (same behaviour as UICollectionView) (See reference https://github.com/TextureGroup/Texture/pull/507#issuecomment-325254620)